### PR TITLE
Add UTF-8 header support

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -3,7 +3,7 @@ package main
 import (
 	stdMail "net/mail"
 
-	"github.com/jordan-wright/email"
+	"gopkg.in/jordan-wright/email.v1"
 	"github.com/zachlatta/postman/mail"
 )
 

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -9,7 +9,7 @@ import (
 	"net/smtp"
 	"text/template"
 
-	"github.com/jordan-wright/email"
+	"gopkg.in/jordan-wright/email.v1"
 )
 
 // Mailer encapsulates data used for sending email.

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/jordan-wright/email"
+	"gopkg.in/jordan-wright/email.v1"
 	"github.com/zachlatta/postman/mail"
 )
 


### PR DESCRIPTION
This change switches our use of @jordan-wright's `email` library to v1.1, which adds support for UTF-8 headers in emails. This should close #19.

@jordan-wright & @nicolasguzca: if either of you want to take point on making sure this works in Postman and then merging this, that'd be awesome! I've added both of you as collaborators to this repo.