### PR TITLE
email package update, support for smtp without authentication, support for untrusted certs

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -3,8 +3,8 @@ package main
 import (
 	stdMail "net/mail"
 
-	"gopkg.in/jordan-wright/email.v1"
 	"github.com/zachlatta/postman/mail"
+	"gopkg.in/jordan-wright/email.v2"
 )
 
 func sendMail(recipient Recipient, emailField string, mailer *mail.Mailer,

--- a/main.go
+++ b/main.go
@@ -43,8 +43,14 @@ func main() {
 	flag.StringVar(&attach, "attach", "", "attach a list of comma separated files")
 	flag.IntVar(&workerCount, "c", 8, "number of concurrent requests to have")
 
-	requiredFlagNames := []string{"text", "csv", "server", "port", "user",
-		"password", "sender", "subject"}
+	requiredFlagNames := []string{
+		"text",
+		"csv",
+		"server",
+		"port",
+		"sender",
+		"subject",
+	}
 	flag.VisitAll(func(f *flag.Flag) {
 		flags = append(flags, f)
 

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"text/template"
 
-	"gopkg.in/jordan-wright/email.v1"
 	"github.com/zachlatta/postman/mail"
+	"gopkg.in/jordan-wright/email.v2"
 )
 
 type Recipient map[string]string
@@ -22,6 +22,7 @@ var (
 	attach                                    string
 	files                                     []string
 	debug                                     bool
+	skipCertValidation                        bool
 	workerCount                               int
 )
 
@@ -38,6 +39,7 @@ func main() {
 	flag.StringVar(&sender, "sender", "", "email to send from")
 	flag.StringVar(&subject, "subject", "", "subject of email")
 	flag.BoolVar(&debug, "debug", false, "print emails to stdout instead of sending")
+	flag.BoolVar(&skipCertValidation, "skipCertValidation", false, "disable tls certificate validation")
 	flag.StringVar(&attach, "attach", "", "attach a list of comma separated files")
 	flag.IntVar(&workerCount, "c", 8, "number of concurrent requests to have")
 
@@ -83,6 +85,7 @@ func main() {
 		smtpPassword,
 		smtpURL,
 		smtpPort,
+		skipCertValidation,
 	)
 
 	jobs := make(chan Recipient, len(*recipients))


### PR DESCRIPTION
## mail Package update
Updated jordan-wright/email from v1 to v2

## Support for smpt without authentication
Some smtp servers does not have authentication, 71ef54f removes user and password flags from required flags, so if they are not explicitly specified the authentication will be none.

## Support for untrusted certs (new flag: *-skipCertValidation*)
The error `x509: certificate is not valid` is common when using self signed certificates. e19ed72 adds support to optionally skip certificate verification and validation. ( So gives a new option to postman ). To make this posible I updated jordan-wright/email to v2 and replaced the mail.send with mail.SendWithTLS.

Quote from README.md
> Features
> - Fast, templated, bulk emails
> - Reads template attributes from CSV
> - Works with any SMTP server .   <---------------- This is a contribution to this

## Backward compatibility

This updates don't breaks the previous version:

- Email package update: the new version of the email package keeps same methods than the previous one and adds TLS optional method.

- Support for untrusted certs: This is disabled by default, to skip certificate validations the flag skipCertValidation must be specified. So none of the process, scripts, etc that are using postman will be affected.

- Support for smtp without authentication: As in the previous version the user and password must be specified explicitly, none of the proceses or scrips that are using postman be affected after upgrade because they still specify the user and password flag.