### PR TITLE
Merge tags for Subject

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/pepa65/postman
+
+go 1.21.5
+
+require gopkg.in/jordan-wright/email.v2 v2.0.0-20160301001728-a62870b0c368

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/jordan-wright/email.v2 v2.0.0-20160301001728-a62870b0c368 h1:btqYnSwwBSj/7nX1bPxyHvyXoIaRxS1MZg8v93NLpwY=
+gopkg.in/jordan-wright/email.v2 v2.0.0-20160301001728-a62870b0c368/go.mod h1:6YiNdSV9gi2BIEp0u8QxxGZU5nxz4RUJvjZlA9dnOYc=

--- a/mail.go
+++ b/mail.go
@@ -3,7 +3,7 @@ package main
 import (
 	stdMail "net/mail"
 
-	"github.com/zachlatta/postman/mail"
+	"github.com/pepa65/postman/mail"
 	"gopkg.in/jordan-wright/email.v2"
 )
 

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -39,7 +39,7 @@ func NewMailer(username, password, host, port string, skipCertValidation bool) M
 
 func NewMessage(from, to *mail.Address, subject string, files []string, templatePath,
 	htmlTemplatePath string, context interface{}) (*email.Email, error) {
-	parsedSubject, err := parseTemplate(subject, context)
+	parsedSubject, err := parseText([]byte(subject), context)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func NewMessage(from, to *mail.Address, subject string, files []string, template
 	msg := &email.Email{
 		From:    from.String(),
 		To:      []string{to.String()},
-		Subject: parsedSubject,
+		Subject: string(parsedSubject),
 	}
 
 	for _, file := range files {
@@ -83,16 +83,18 @@ func parseTemplate(templatePath string, context interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseText(tmplBytes, context)
+}
 
+func parseText(tmplBytes []byte, context interface{}) ([]byte, error) {
 	t := template.Must(template.New("emailBody").Parse(string(tmplBytes)))
-
-	var doc bytes.Buffer
-	err = t.Execute(&doc, context)
+	var txt bytes.Buffer
+	err := t.Execute(&txt, context)
 	if err != nil {
 		return nil, err
 	}
 
-	return doc.Bytes(), nil
+	return txt.Bytes(), nil
 }
 
 // Send sends an email Message.

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -39,10 +39,15 @@ func NewMailer(username, password, host, port string, skipCertValidation bool) M
 
 func NewMessage(from, to *mail.Address, subject string, files []string, templatePath,
 	htmlTemplatePath string, context interface{}) (*email.Email, error) {
+	parsedSubject, err := parseTemplate(subject, context)
+	if err != nil {
+		return nil, err
+	}
+
 	msg := &email.Email{
 		From:    from.String(),
 		To:      []string{to.String()},
-		Subject: subject,
+		Subject: parsedSubject,
 	}
 
 	for _, file := range files {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/zachlatta/postman/mail"
+	"github.com/pepa65/postman/mail"
 	"gopkg.in/jordan-wright/email.v2"
 )
 


### PR DESCRIPTION
Parse the subject line to replace tags from the CSV file. Fixes https://github.com/zachlatta/postman/issues/16

I think I had to change the repo locations from `zachlatta` to `pepa65` in `/mail.go` and `main.go`, you will want to edit that in this pull request.